### PR TITLE
[DMC] Fixed bots only using the "gordon" model

### DIFF
--- a/dlls/dir.cpp
+++ b/dlls/dir.cpp
@@ -113,6 +113,38 @@ HANDLE FindDirectory(HANDLE hFile, char* dirname, char* dirspec)
 	}
 }
 
+/// <summary>
+/// Returns true if the path has any sub-directories
+/// </summary>
+bool HasSubDirectories(char* path) {
+	char search_path[MAX_PATH];
+	char dirname[MAX_PATH];
+#ifndef __linux__
+	HANDLE directory = nullptr;
+#else
+	DIR* directory = nullptr;
+#endif
+
+
+	std::strcpy(search_path, path);
+
+#ifndef __linux__
+	std::strcat(search_path, "/*");
+#endif
+
+	// check if there's any sub-directories in the MOD models/player
+	while ((directory = FindDirectory(directory, dirname, search_path)) != nullptr) {
+		// don't want to get stuck looking in the same directory again and again (".")
+		// don't wan't to search parent directories ("..")
+		if (std::strcmp(dirname, ".") == 0 || std::strcmp(dirname, "..") == 0)
+			continue;
+		
+		return true;
+	}
+
+	return false;
+}
+
 #else
 
 // Linux directory wildcard routines...

--- a/dlls/dir.h
+++ b/dlls/dir.h
@@ -56,4 +56,6 @@ DIR* FindDirectory(DIR* directory, char* dirname, char* dirspec);
 
 #endif
 
+bool HasSubDirectories(char* path);
+
 #endif

--- a/dlls/globals.cpp
+++ b/dlls/globals.cpp
@@ -1375,9 +1375,9 @@ void CBotGlobals::LoadBotModels()
 	std::strcat(path, "\\models\\player");
 #endif
 
-	if (stat(path, &stat_str) != 0)
+	if (stat(path, &stat_str) != 0 || !HasSubDirectories(path))
 	{
-		// use the valve/models/player directory if no MOD models/player
+		// use the valve/models/player directory if no valid MOD models/player
 #ifdef __linux__
 		std::strcpy(path, "valve/models/player");
 #else


### PR DESCRIPTION
Noticed when playing DMC that all the bots would just use gordon player model, and tracked it down to the cause that `dmc/models/player` contained a `remapped.bmp` file, which appears to be generated by the engine when changing player models. 

The fact that this folder existed was enough to make the bots use the `dmc/models/player` folder to get the list of which models to use. This folder contained no models, and thus every bot defaulted to "gordon" player model.

This PR adds another check to see if there's any sub-folders inside `models/player` before it decides to use it.

This was tested on DMC but I suspect it might impact other mods if they follow the same logic.